### PR TITLE
22 tags/tags_timers テーブル・モデル定義

### DIFF
--- a/backend/migrations/2020-09-20-123259_create_tags/down.sql
+++ b/backend/migrations/2020-09-20-123259_create_tags/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE tags;

--- a/backend/migrations/2020-09-20-123259_create_tags/up.sql
+++ b/backend/migrations/2020-09-20-123259_create_tags/up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE tags (
+    id SERIAL PRIMARY KEY,
+    uid VARCHAR(127) NOT NULL,
+    name VARCHAR(255) NOT NULL
+);

--- a/backend/migrations/2020-09-23-092300_create_tags_timers/down.sql
+++ b/backend/migrations/2020-09-23-092300_create_tags_timers/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE tags_timers;

--- a/backend/migrations/2020-09-23-092300_create_tags_timers/up.sql
+++ b/backend/migrations/2020-09-23-092300_create_tags_timers/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE tags_timers (
+    tag_id INTEGER REFERENCES tags(id) NOT NULL,
+    timer_id INTEGER REFERENCES timers(id) NOT NULL
+);
+CREATE INDEX tag_id_index ON tags_timers(tag_id);
+CREATE INDEX timer_id_index ON tags_timers(timer_id);

--- a/backend/migrations/2020-09-23-092300_create_tags_timers/up.sql
+++ b/backend/migrations/2020-09-23-092300_create_tags_timers/up.sql
@@ -1,6 +1,7 @@
 CREATE TABLE tags_timers (
     tag_id INTEGER REFERENCES tags(id) NOT NULL,
-    timer_id INTEGER REFERENCES timers(id) NOT NULL
+    timer_id INTEGER REFERENCES timers(id) NOT NULL,
+    PRIMARY KEY (tag_id, timer_id)
 );
 CREATE INDEX tag_id_index ON tags_timers(tag_id);
 CREATE INDEX timer_id_index ON tags_timers(timer_id);

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -17,6 +17,13 @@ table! {
 }
 
 table! {
+    tags_timers (tag_id, timer_id) {
+        tag_id -> Int4,
+        timer_id -> Int4,
+    }
+}
+
+table! {
     timers (id) {
         id -> Int4,
         uid -> Varchar,
@@ -33,10 +40,13 @@ table! {
 }
 
 joinable!(records -> timers (timer_id));
+joinable!(tags_timers -> tags (tag_id));
+joinable!(tags_timers -> timers (timer_id));
 
 allow_tables_to_appear_in_same_query!(
     records,
     tags,
+    tags_timers,
     timers,
     users,
 );

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -9,6 +9,14 @@ table! {
 }
 
 table! {
+    tags (id) {
+        id -> Int4,
+        uid -> Varchar,
+        name -> Varchar,
+    }
+}
+
+table! {
     timers (id) {
         id -> Int4,
         uid -> Varchar,
@@ -28,6 +36,7 @@ joinable!(records -> timers (timer_id));
 
 allow_tables_to_appear_in_same_query!(
     records,
+    tags,
     timers,
     users,
 );


### PR DESCRIPTION
tags_timers は主キー用の連番を振らずに、tag_id と timer_id の複合キーとしました。